### PR TITLE
feat: `serde::redacted` convenience `serialize_with` - serialize without exposing

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ struct Payment {
 }
 ```
 
-If you would like to implement `Serialize` without exposing the `Secret` see [serde::redacted].
+If you would like to implement `Serialize` without exposing the `Secret` see [serde::redact_secret].
 
 ## Comparison with alternatives
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ struct Payment {
 }
 ```
 
+If you would like to implement `Serialize` without exposing the `Secret` see [serde::redacted].
+
 ## Comparison with alternatives
 
 ### [secrecy](https://docs.rs/secrecy/latest/secrecy/)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ mod error;
 mod fake;
 mod ops;
 #[cfg(feature = "serde")]
-mod serde;
+pub mod serde;
 
 #[cfg(feature = "serde")]
 pub use crate::serde::expose_secret;

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -71,7 +71,10 @@ pub fn expose_secret<S: Serializer, T: Serialize>(
 /// *This API requires the following crate features to be activated: `serde`*
 #[cfg(feature = "serde")]
 #[inline]
-pub fn redacted<S: Serializer, T>(secret: &Secret<T>, serializer: S) -> Result<S::Ok, S::Error> {
+pub fn redact_secret<S: Serializer, T>(
+    secret: &Secret<T>,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
     format!("{secret:?}").serialize(serializer)
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -42,7 +42,6 @@ impl<T: Serialize> SerializableSecret<T> for Option<Secret<T>> {
     }
 }
 
-#[cfg(feature = "serde")]
 /// Exposes a [Secret] for serialization.
 ///
 /// For general-purpose secret exposing see [Secret::expose_secret].
@@ -50,6 +49,7 @@ impl<T: Serialize> SerializableSecret<T> for Option<Secret<T>> {
 /// See [module level documentation][crate] for usage example.
 ///
 /// *This API requires the following crate features to be activated: `serde`*
+#[cfg(feature = "serde")]
 #[inline]
 pub fn expose_secret<S: Serializer, T: Serialize>(
     secret: &impl SerializableSecret<T>,
@@ -60,6 +60,15 @@ pub fn expose_secret<S: Serializer, T: Serialize>(
         .serialize(serializer)
 }
 
+/// Serialize a redacted [Secret] without exposing the contained data.
+///
+/// The secret will be serialized as its [`Debug`] output.
+/// Since the data is redacted, it is not possible to deserialize data serialized in this way.
+///
+/// This function is designed to be used with `#[serde(serialize_with)]` in the same way as
+/// [serde::expose_secret][crate::serde::expose_secret].
+///
+/// *This API requires the following crate features to be activated: `serde`*
 #[cfg(feature = "serde")]
 #[inline]
 pub fn redacted<S: Serializer, T>(secret: &Secret<T>, serializer: S) -> Result<S::Ok, S::Error> {

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -60,6 +60,12 @@ pub fn expose_secret<S: Serializer, T: Serialize>(
         .serialize(serializer)
 }
 
+#[cfg(feature = "serde")]
+#[inline]
+pub fn redacted<S: Serializer, T>(secret: &Secret<T>, serializer: S) -> Result<S::Ok, S::Error> {
+    format!("{secret:?}").serialize(serializer)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
resolves #45 

# Todo
- [x] Document function with rustdoc
- [x] Update serde section in `README.md`
