### PR TITLE
chore: add all-features redact to `dev-dependencies`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ rand = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 
 [dev-dependencies]
+redact = { features = ["serde", "fake"], path = "." }
 fake = { version = "2.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
This enables `cargo test` to be run without having to pass `--all-features`
