### PR TITLE
fix: remove `serde` feature dependency on `std`

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -75,7 +75,7 @@ pub fn redact_secret<S: Serializer, T>(
     secret: &Secret<T>,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
-    format!("{secret:?}").serialize(serializer)
+    serializer.collect_str(&format_args!("{secret:?}"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This was introduced in https://github.com/eopb/redact/pull/46 and is required for https://github.com/eopb/redact/pull/50
