### PR TITLE
feat: impl `Deref` and `DerefMut` without exposing `Secret`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ fake = ["dep:fake", "dep:rand"]
 serde = ["dep:serde"]
 
 [dependencies]
+bytemuck = { version = "1.15", default-features = false }
 fake = { version = "2.5", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![forbid(unsafe_code)]
 
 #[cfg(feature = "std")]
 mod error;


### PR DESCRIPTION
I'm not sure what the usecase for this is.
Originally I thought it was required for https://github.com/eopb/redact/pull/58 but I was wrong.

It was fun implementing this with a bit of unsafe but I don't know if I'll merge it.
