### PR TITLE
fix: removing `Secret::zeroizing` method

### DIFF
--- a/src/zeroize.rs
+++ b/src/zeroize.rs
@@ -15,9 +15,3 @@ impl<T: TryZeroize> TryZeroize for Secret<T> {
 }
 
 impl<T: ZeroizeOnDrop> ZeroizeOnDrop for Secret<T> {}
-
-impl<T: Zeroize> Secret<T> {
-    pub fn zeroizing(self) -> zeroize::Zeroizing<Self> {
-        zeroize::Zeroizing::new(self)
-    }
-}


### PR DESCRIPTION
This was introduced by mistake in https://github.com/eopb/redact/pull/58. I don't want to commit to keeping this API. It makes zeroizing too prominent in the API docs
