### PR TITLE
docs: update for `SerializableSecret`

### DIFF
--- a/src/serde.rs
+++ b/src/serde.rs
@@ -12,11 +12,8 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for Secret<T> {
 
 /// A serializable type that contains a secret.
 ///
-/// This abstraction enables [expose_secret] to be used to serialize both `Secret<T>` and
-/// `Option<Secret<T>>`.
-///
-/// This type is currently private. If you feel that a public `SerializableSecret` could
-/// be useful for your use case please open a PR :)
+/// This abstraction enables [expose_secret] to be used to serialize both `Secret<T>`, `&Secret<T>`
+/// and `Option<Secret<T>>`.
 pub trait SerializableSecret<T> {
     type Exposed<'a>: Serialize
     where


### PR DESCRIPTION
This type was unintentionally made public in https://github.com/eopb/redact/pull/46

Since that was a few releases ago, I think it'd be probably best to keep it public.

`redact` attempts to be stable, I don't want to risk breaking any code.