### PR TITLE
fix: repeat versions in dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,10 @@ zeroize = { version = "1.7", optional = true, default-features = false }
 
 [dev-dependencies]
 redact = { features = ["serde", "fake", "zeroize"], path = "." }
-fake = { features = ["derive"] }
-serde = { features = ["derive"] }
+fake = { version = "2.5", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-zeroize = { features = ["std"] }
+zeroize = { version = "1.7", features = ["std"] }
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
Cargo is no longer happy with me not specifying versions of dev-dependencies. Previously this was okay if I only wanted to update the feature set of a dependency for tests.

On stable
```
warning: dependency (fake) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
warning: dependency (serde) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
warning: dependency (zeroize) specified without providing a local path, Git repository, version, or workspace dependency to use. This will be considered an error in future versions
```

On nightly
```
error: failed to parse manifest at `/home/runner/work/redact/redact/Cargo.toml`

Caused by:
  dependency (fake) specified without providing a local path, Git repository, version, or workspace dependency to use
```