### PR TITLE
ci: use `cargo hack` to check msrv

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,18 +53,12 @@ jobs:
       - name: cargo check
         run: cargo check --locked --all-features
   msrv:
+    name: "Check MSRV"
     runs-on: ubuntu-latest
-    # we use a matrix here just because env can't be used in job names
-    # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
-    strategy:
-      matrix:
-        msrv: [1.65.0]
-    name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v3
-      - name: Install ${{ matrix.msrv }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.msrv }}
-      - name: cargo +${{ matrix.msrv }} check
-        run: cargo check --all-features
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/install-action@cargo-hack
+      - name: Default features
+        run: cargo hack check --feature-powerset --rust-version --ignore-private --workspace --all-targets


### PR DESCRIPTION
This fetches our MSRV from our `Cargo.toml` file so we don't have to repeat it in our CI script.

Based on https://github.com/eopb/cargo-override/pull/116
